### PR TITLE
feat: add Quarto Wizard schema and snippets

### DIFF
--- a/_extensions/progressvg/_schema.yml
+++ b/_extensions/progressvg/_schema.yml
@@ -1,0 +1,24 @@
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+attributes:
+  progressvg:
+    file:
+      type: string
+      required: true
+      description: Path to the SVG file to control.
+      completion:
+        type: file
+        extensions: [.svg]
+    element:
+      type: string
+      required: true
+      description: SVG element id or Inkscape label to show or hide.
+    action:
+      type: string
+      default: show
+      enum: [show, hide]
+      description: Whether the target element should be shown or hidden.
+
+classes:
+  progressvg:
+    description: Wrapper div that registers progressive SVG visibility changes.

--- a/_extensions/progressvg/_snippets.json
+++ b/_extensions/progressvg/_snippets.json
@@ -1,6 +1,6 @@
 {
   "Show SVG element": {
-    "prefix": "progressvg-show",
+    "prefix": "show",
     "body": [
       "::: {.progressvg file=\"${1:diagram.svg}\" element=\"${2:axes}\"}",
       ":::"
@@ -8,7 +8,7 @@
     "description": "Insert a progressvg trigger that shows an SVG element."
   },
   "Hide SVG element": {
-    "prefix": "progressvg-hide",
+    "prefix": "hide",
     "body": [
       "::: {.progressvg file=\"${1:diagram.svg}\" element=\"${2:old_data}\" action=\"hide\"}",
       ":::"

--- a/_extensions/progressvg/_snippets.json
+++ b/_extensions/progressvg/_snippets.json
@@ -1,0 +1,18 @@
+{
+  "Show SVG element": {
+    "prefix": "progressvg-show",
+    "body": [
+      "::: {.progressvg file=\"${1:diagram.svg}\" element=\"${2:axes}\"}",
+      ":::"
+    ],
+    "description": "Insert a progressvg trigger that shows an SVG element."
+  },
+  "Hide SVG element": {
+    "prefix": "progressvg-hide",
+    "body": [
+      "::: {.progressvg file=\"${1:diagram.svg}\" element=\"${2:old_data}\" action=\"hide\"}",
+      ":::"
+    ],
+    "description": "Insert a progressvg trigger that hides an SVG element."
+  }
+}


### PR DESCRIPTION
This PR improves Quarto Wizard support (VS Code/Positron) for this extension by adding extension metadata files used for editor assistance.

### What this adds
- `_schema.yml` with extension-specific fields (options/classes/attributes and/or format keys) to enable better completion, hover docs, and validation.
- `_snippets.json` with practical insertion snippets for common extension usage.

### Why
These files improve authoring UX in Quarto projects by making extension configuration and usage easier to discover and less error-prone in VSCode/Positron when using Quarto Wizard.

### References
- Schema specification: https://m.canouil.dev/quarto-wizard/reference/schema-specification.html
- Snippet specification: https://m.canouil.dev/quarto-wizard/reference/snippet-specification.html